### PR TITLE
Make rst2man optional, put enable_testing in outermost scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
+
+# Here you can set your VMOD name
+# A unique VMOD name will allow your VMOD to live among other
+# VMODs in a larger build system, as well as automatically set
+# the appropriate output filename.
+# For "example" the output will be "libvmod_example.so".
 set(VMOD_NAME example)
+
 project(vmod_${VMOD_NAME} VERSION 0.0.1)
 
 include(vmod.cmake)

--- a/vmod.cmake
+++ b/vmod.cmake
@@ -1,39 +1,45 @@
+enable_testing()
+
 function (vtc vmod_name vtc_paths)
-	enable_testing()
 	foreach(vtc_path ${vtc_paths})
 		add_test(NAME ${vtc_path} COMMAND varnishtest -v "-Dvmod_${vmod_name}=${vmod_name} from \"${CMAKE_BINARY_DIR}/libvmod_${vmod_name}.so\"" ${vtc_path})
 		set_tests_properties(${vtc_path} PROPERTIES SKIP_RETURN_CODE 77)
 	endforeach()
 endfunction()
 
-function (vmod vmod_name vc_api_req src_files) 
+function (vmod vmod_name vc_api_req src_files)
 	find_package(PkgConfig REQUIRED)
 	find_package(Python REQUIRED COMPONENTS Interpreter Development)
-	
+
 	find_program(RST2MAN rst2man)
-	
+
 	pkg_check_modules(VARNISHAPI REQUIRED varnishapi>=${vc_api_req})
 	pkg_get_variable(VARNISHAPI_VMODTOOL varnishapi vmodtool)
 	pkg_get_variable(VARNISHAPI_VMODDIR varnishapi vmoddir)
 	include_directories(${VARNISHAPI_INCLUDE_DIRS})
-	include_directories(${CMAKE_BINARY_DIR})
+	include_directories(${CMAKE_CURRENT_BINARY_DIR})
 	configure_file(config.h.in config.h)
-	
+
 	add_custom_command(
-		OUTPUT vcc_${vmod_name}_if.c vcc_${vmod_name}_if.h vmod_${vmod_name}.rst vmod_${vmod_name}.man.rst
-		MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/src/vmod_${vmod_name}.vcc
-		COMMAND ${Python_EXECUTABLE}
-		ARGS ${VARNISHAPI_VMODTOOL} -o vcc_${vmod_name}_if ${CMAKE_CURRENT_SOURCE_DIR}/src/vmod_${vmod_name}.vcc
+		OUTPUT "vcc_${vmod_name}_if.c" "vcc_${vmod_name}_if.h" "vmod_${vmod_name}.rst" "vmod_${vmod_name}.man.rst"
+		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/src/vmod_${vmod_name}.vcc"
+		COMMAND "${Python_EXECUTABLE}"
+		ARGS "${VARNISHAPI_VMODTOOL}" -o "vcc_${vmod_name}_if" "${CMAKE_CURRENT_SOURCE_DIR}/src/vmod_${vmod_name}.vcc"
 	)
-	
-	add_library(vmod_${vmod_name} MODULE ${src_files} vcc_${vmod_name}_if.c vcc_${vmod_name}_if.h)
+
+	add_library(vmod_${vmod_name} MODULE ${src_files} "vcc_${vmod_name}_if.c" "vcc_${vmod_name}_if.h")
 	install(TARGETS vmod_${vmod_name} DESTINATION ${VARNISHAPI_VMODDIR})
-	
-	add_custom_command(
-		OUTPUT vmod_${vmod_name}.3
-		MAIN_DEPENDENCY ${CMAKE_BINARY_DIR}/vmod_${vmod_name}.rst
-		COMMAND ${RST2MAN} ${CMAKE_BINARY_DIR}/vmod_${vmod_name}.rst vmod_${vmod_name}.3
-	)
-	add_custom_target(manpage ALL DEPENDS ${CMAKE_BINARY_DIR}/vmod_${vmod_name}.3)
-	install(FILES ${CMAKE_BINARY_DIR}/vmod_${vmod_name}.3 TYPE MAN)
+
+	# Documentation can be generated and installed if python3-docutils is installed.
+	if (RST2MAN)
+		add_custom_command(
+			OUTPUT "vmod_${vmod_name}.3"
+			MAIN_DEPENDENCY "${CMAKE_CURRENT_BINARY_DIR}/vmod_${vmod_name}.rst"
+			COMMAND ${RST2MAN} "${CMAKE_CURRENT_BINARY_DIR}/vmod_${vmod_name}.rst" "vmod_${vmod_name}.3"
+		)
+		add_custom_target(manpage ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/vmod_${vmod_name}.3")
+		install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vmod_${vmod_name}.3" TYPE MAN)
+	else()
+		message(WARNING "Documentation skipped. rst2man from python3-docutils is missing.")
+	endif()
 endfunction()


### PR DESCRIPTION
This changes 3 things as of now:
1. rst2man is now optional. It was not required before so it would just failed to build - now it will just skip the docs and give a warning.
2. The binary files are put into CMAKE_CURRENT_BINARY_DIR which is the binary directory of the current (libvmod_example) project. This will make it work nicely inside a bigger project.
3. The testing was not enabled because enable_testing was inside a function - now it its in the outermost scope because includes are actual cut and paste, as is tradition.

There are 2 things that may have to be done to make this the ultimate vmod.cmake:
1. Detect that you are inside a larger build system and not use the system libvarnishapi. In that case you should use the libvarnishapi of the build system. This will allow things like fuzzing and sanitizing vmods and Varnish at the same time, per build folder. Very handy.
2. Detect Varnish Plus and simply set VARNISH_PLUS in CMake as well as adding a -DVARNISH_PLUS to VMODs.
